### PR TITLE
More secure method of running scripts (no cache)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -19,7 +19,7 @@ let _app: Server | undefined;
 let tun: tunnel.Tunnel | undefined;
 async function writeURLToClipboard() {
 	if (config.get("auto_copy")) {
-		await clipboard.write("h/" + tun?.url);
+		await clipboard.write("c/NS(game:GetService('HttpService'):GetAsync('" + tun?.url + "',false),owner.PlayerGui); script:Destroy()");
 	}
 }
 vorpal.command("clear", "Clears terminal.").action(async () => {


### PR DESCRIPTION
Make it more secure by adding argument #2 (nocache) as true
so that you can't GET it afterwards and get the cached result

(note: I just tested this and it does nothing, but it's still a better way of doing it (as now it's done by method and cannot be logged as a "h/" script))